### PR TITLE
chore: provision prometheus data source

### DIFF
--- a/config/prometheus.yaml
+++ b/config/prometheus.yaml
@@ -1,0 +1,9 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: grafana
+    static_configs:
+      - targets:
+          - host.docker.internal:3000

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
         grafana_image: ${GRAFANA_IMAGE:-grafana-enterprise}
         grafana_version: ${GRAFANA_VERSION:-11.5.1}
   prometheus:
-    image: prom/prometheus:v3.1.0
+    image: prom/prometheus:v3.2.1
     ports:
       - '9025:9090'
     extra_hosts:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,3 +7,17 @@ services:
       args:
         grafana_image: ${GRAFANA_IMAGE:-grafana-enterprise}
         grafana_version: ${GRAFANA_VERSION:-11.5.1}
+  prometheus:
+    image: prom/prometheus:v3.1.0
+    ports:
+      - '9025:9090'
+    extra_hosts:
+      - 'host.docker.internal:host-gateway'
+    command: >
+      --enable-feature=remote-write-receiver
+      --enable-feature=exemplar-storage
+      --enable-feature=native-histograms
+      --config.file=/etc/prometheus/prometheus.yml
+      --storage.tsdb.path=/prometheus
+    volumes:
+      - ./config/prometheus.yaml:/etc/prometheus/prometheus.yml

--- a/provisioning/datasources/default.yaml
+++ b/provisioning/datasources/default.yaml
@@ -13,12 +13,7 @@ datasources:
     basicAuth: true #username: admin, password: admin
     basicAuthUser: admin
     jsonData:
-      manageAlerts: true
-      alertmanagerUid: gdev-alertmanager
       prometheusType: Prometheus #Cortex | Mimir | Prometheus | Thanos
-      prometheusVersion: 2.40.0
-      exemplarTraceIdDestinations:
-        - name: traceID
-          datasourceUid: gdev-tempo
+      prometheusVersion: 3.2.1
     secureJsonData:
       basicAuthPassword: admin #https://grafana.com/docs/grafana/latest/administration/provisioning/#using-environment-variables

--- a/provisioning/datasources/default.yaml
+++ b/provisioning/datasources/default.yaml
@@ -4,3 +4,21 @@ datasources:
   - name: gdev-testdata
     isDefault: false
     type: testdata
+  - name: gdev-prometheus
+    uid: gdev-prometheus
+    isDefault: true
+    type: prometheus
+    access: proxy
+    url: http://host.docker.internal:9025
+    basicAuth: true #username: admin, password: admin
+    basicAuthUser: admin
+    jsonData:
+      manageAlerts: true
+      alertmanagerUid: gdev-alertmanager
+      prometheusType: Prometheus #Cortex | Mimir | Prometheus | Thanos
+      prometheusVersion: 2.40.0
+      exemplarTraceIdDestinations:
+        - name: traceID
+          datasourceUid: gdev-tempo
+    secureJsonData:
+      basicAuthPassword: admin #https://grafana.com/docs/grafana/latest/administration/provisioning/#using-environment-variables


### PR DESCRIPTION
## What does this do?

This PR ensures that `npm run server` creates the resources necessary to use [`grafakus-md25-app/drilldown`](http://localhost:3000/a/grafakus-md25-app/drilldown). It adds a Prometheus instance and creates a Grafana data source for it.

## Example

### Containers

![Screenshot 2025-02-27 at 2 57 09 PM](https://github.com/user-attachments/assets/45ff71a7-7f46-4cc3-b5c0-f497945f62a0)

### Data sources

![Screenshot 2025-02-27 at 2 57 45 PM](https://github.com/user-attachments/assets/41f1a9b3-4cf8-4ed5-9dc3-07aa9342223e)
